### PR TITLE
Fix invalid URI's in CXTM and TMAPI-tests

### DIFF
--- a/cxtm-tests/assembly/resources/jtm/baseline/subjid-escaping.xtm2.jtm.cxtm
+++ b/cxtm-tests/assembly/resources/jtm/baseline/subjid-escaping.xtm2.jtm.cxtm
@@ -1,7 +1,7 @@
 <topicMap>
 <topic number="1">
 <subjectIdentifiers>
-<locator>http://example.org/test folder/#topic</locator>
+<locator>http://example.org/test+folder/#topic</locator>
 </subjectIdentifiers>
 <itemIdentifiers>
 <locator>#topic</locator>

--- a/cxtm-tests/assembly/resources/jtm/baseline/subjid-escaping2.xtm2.jtm.cxtm
+++ b/cxtm-tests/assembly/resources/jtm/baseline/subjid-escaping2.xtm2.jtm.cxtm
@@ -1,7 +1,7 @@
 <topicMap>
 <topic number="1">
 <subjectIdentifiers>
-<locator>http://example.org/test folder/#topic</locator>
+<locator>http://example.org/test%20folder/#topic</locator>
 </subjectIdentifiers>
 <itemIdentifiers>
 <locator>#topic</locator>

--- a/cxtm-tests/assembly/resources/xtm2/baseline/subjid-escaping.xtm.cxtm
+++ b/cxtm-tests/assembly/resources/xtm2/baseline/subjid-escaping.xtm.cxtm
@@ -1,7 +1,7 @@
 <topicMap>
 <topic number="1">
 <subjectIdentifiers>
-<locator>http://example.org/test folder/#topic</locator>
+<locator>http://example.org/test+folder/#topic</locator>
 </subjectIdentifiers>
 <itemIdentifiers>
 <locator>#topic</locator>

--- a/cxtm-tests/assembly/resources/xtm2/baseline/subjid-escaping2.xtm.cxtm
+++ b/cxtm-tests/assembly/resources/xtm2/baseline/subjid-escaping2.xtm.cxtm
@@ -1,7 +1,7 @@
 <topicMap>
 <topic number="1">
 <subjectIdentifiers>
-<locator>http://example.org/test folder/#topic</locator>
+<locator>http://example.org/test%20folder/#topic</locator>
 </subjectIdentifiers>
 <itemIdentifiers>
 <locator>#topic</locator>

--- a/cxtm-tests/pom.xml
+++ b/cxtm-tests/pom.xml
@@ -9,7 +9,7 @@
 	
 	<groupId>net.ontopia</groupId>
 	<artifactId>cxtm-tests</artifactId>
-	<version>1</version>
+	<version>2</version>
 	<packaging>pom</packaging>
 	
 	<name>CXTM tests</name>

--- a/tmapi-tests/pom.xml
+++ b/tmapi-tests/pom.xml
@@ -9,7 +9,7 @@
 
 	<groupId>net.ontopia.external.org.tmapi</groupId>
 	<artifactId>tmapi-tests</artifactId>
-	<version>2.0.2</version>
+	<version>2.0.2.1</version>
 	
 	<name>TMAPI Tests</name>
 	<description>Test cases for the TMAPI programming interface for accessing and manipulating data held in a topic map.</description>
@@ -61,7 +61,7 @@
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>tmapi</artifactId>
-			<version>${project.version}</version>
+			<version>2.0.2</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/tmapi-tests/src/main/java/org/tmapi/core/TestLocator.java
+++ b/tmapi-tests/src/main/java/org/tmapi/core/TestLocator.java
@@ -31,20 +31,20 @@ public class TestLocator extends TMAPITestCase {
         final Locator loc2 = loc.resolve("./too");
         assertEquals("http://www.example.org/test%20me/too", loc2.toExternalForm());
 
-		/* qs@2018-03-07
+    /* qs@2018-03-07
 
-		The following disabled assertions are not legal:
-		- Locators should not encode or decode during construction or as method result as en-/decoding is scheme specific
-		- Locator contructor should not accept an illegal URI
-		
+    The following disabled assertions are not legal:
+    - Locators should not encode or decode during construction or as method result as en-/decoding is scheme specific
+    - Locator contructor should not accept an illegal URI
+
         assertEquals("http://www.example.org/test me/", loc.getReference());
         assertEquals("http://www.example.org/test me/too", loc2.getReference());
         final Locator loc3 = _tm.createLocator("http://www.example.org/test me/");
         assertEquals("http://www.example.org/test me/", loc3.getReference());
         assertEquals("http://www.example.org/test%20me/", loc3.toExternalForm());
         assertEquals(loc, loc3);
-		
-		*/
+
+    */
     }
 
     public void testIllegalLocatorAddresses() {

--- a/tmapi-tests/src/main/java/org/tmapi/core/TestLocator.java
+++ b/tmapi-tests/src/main/java/org/tmapi/core/TestLocator.java
@@ -27,15 +27,24 @@ public class TestLocator extends TMAPITestCase {
 
     public void testNormalization() {
         final Locator loc = _tm.createLocator("http://www.example.org/test%20me/");
-        assertEquals("http://www.example.org/test me/", loc.getReference());
         assertEquals("http://www.example.org/test%20me/", loc.toExternalForm());
         final Locator loc2 = loc.resolve("./too");
-        assertEquals("http://www.example.org/test me/too", loc2.getReference());
         assertEquals("http://www.example.org/test%20me/too", loc2.toExternalForm());
+
+		/* qs@2018-03-07
+
+		The following disabled assertions are not legal:
+		- Locators should not encode or decode during construction or as method result as en-/decoding is scheme specific
+		- Locator contructor should not accept an illegal URI
+		
+        assertEquals("http://www.example.org/test me/", loc.getReference());
+        assertEquals("http://www.example.org/test me/too", loc2.getReference());
         final Locator loc3 = _tm.createLocator("http://www.example.org/test me/");
         assertEquals("http://www.example.org/test me/", loc3.getReference());
         assertEquals("http://www.example.org/test%20me/", loc3.toExternalForm());
         assertEquals(loc, loc3);
+		
+		*/
     }
 
     public void testIllegalLocatorAddresses() {


### PR DESCRIPTION
As per ontopia/ontopia#543:

- Fixed the cxtm baselines containing illegal URI's
- Disabled the TMAPI test assertions that rely on parsing invalid URI's